### PR TITLE
Mark Ops traits as Serializable

### DIFF
--- a/output/src/main/scala/fix/AddSummoner.scala
+++ b/output/src/main/scala/fix/AddSummoner.scala
@@ -18,13 +18,13 @@ object MissingCompanionAndSummoner {
    */
   @inline def apply[F[_]](implicit instance: MissingCompanionAndSummoner[F]): MissingCompanionAndSummoner[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: MissingCompanionAndSummoner[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToMissingCompanionAndSummonerOps {
+  trait ToMissingCompanionAndSummonerOps extends Serializable {
     implicit def toMissingCompanionAndSummonerOps[F[_], A](target: F[A])(implicit tc: MissingCompanionAndSummoner[F]): Ops[F, A] {
       type TypeClassType = MissingCompanionAndSummoner[F]
     } = new Ops[F, A] {
@@ -67,13 +67,13 @@ object MissingSummoner {
    */
   @inline def apply[F[_]](implicit instance: MissingSummoner[F]): MissingSummoner[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: MissingSummoner[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToMissingSummonerOps {
+  trait ToMissingSummonerOps extends Serializable {
     implicit def toMissingSummonerOps[F[_], A](target: F[A])(implicit tc: MissingSummoner[F]): Ops[F, A] {
       type TypeClassType = MissingSummoner[F]
     } = new Ops[F, A] {

--- a/output/src/main/scala/fix/Alternative.scala
+++ b/output/src/main/scala/fix/Alternative.scala
@@ -47,14 +47,14 @@ object Alternative extends AlternativeFunctions {
    */
   @inline def apply[F[_]](implicit instance: Alternative[F]): Alternative[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Alternative[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
     def unite[G[_], B](implicit ev$1: A <:< G[B], FM: Monad[F], G: Bifoldable[G]): F[B] = typeClassInstance.unite[G, B](self.asInstanceOf[F[G[B]]])(FM, G)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToAlternativeOps {
+  trait ToAlternativeOps extends Serializable {
     implicit def toAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): Ops[F, A] {
       type TypeClassType = Alternative[F]
     } = new Ops[F, A] {

--- a/output/src/main/scala/fix/Apply.scala
+++ b/output/src/main/scala/fix/Apply.scala
@@ -49,7 +49,7 @@ object Apply {
    */
   @inline def apply[F[_]](implicit instance: Apply[F]): Apply[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Apply[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -60,7 +60,7 @@ object Apply {
   trait AllOps[F[_], A] extends Ops[F, A] with InvariantSemigroupal.AllOps[F, A] {
     type TypeClassType <: Apply[F]
   }
-  trait ToApplyOps {
+  trait ToApplyOps extends Serializable {
     implicit def toApplyOps[F[_], A](target: F[A])(implicit tc: Apply[F]): Ops[F, A] {
       type TypeClassType = Apply[F]
     } = new Ops[F, A] {
@@ -121,7 +121,7 @@ object FlatMap {
    */
   @inline def apply[F[_]](implicit instance: FlatMap[F]): FlatMap[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: FlatMap[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -131,7 +131,7 @@ object FlatMap {
   trait AllOps[F[_], A] extends Ops[F, A] with Apply.AllOps[F, A] {
     type TypeClassType <: FlatMap[F]
   }
-  trait ToFlatMapOps {
+  trait ToFlatMapOps extends Serializable {
     implicit def toFlatMapOps[F[_], A](target: F[A])(implicit tc: FlatMap[F]): Ops[F, A] {
       type TypeClassType = FlatMap[F]
     } = new Ops[F, A] {

--- a/output/src/main/scala/fix/Compose.scala
+++ b/output/src/main/scala/fix/Compose.scala
@@ -37,7 +37,7 @@ object Compose {
    */
   @inline def apply[F[_, _]](implicit instance: Compose[F]): Compose[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Compose[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -46,7 +46,7 @@ object Compose {
     def >>>[C](g: F[B, C]): F[A, C] = typeClassInstance.andThen[A, B, C](self, g)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
-  trait ToComposeOps {
+  trait ToComposeOps extends Serializable {
     implicit def toComposeOps[F[_, _], A, B](target: F[A, B])(implicit tc: Compose[F]): Ops[F, A, B] {
       type TypeClassType = Compose[F]
     } = new Ops[F, A, B] {
@@ -86,7 +86,7 @@ object Category {
    */
   @inline def apply[F[_, _]](implicit instance: Category[F]): Category[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Category[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -94,7 +94,7 @@ object Category {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Compose.AllOps[F, A, B] {
     type TypeClassType <: Category[F]
   }
-  trait ToCategoryOps {
+  trait ToCategoryOps extends Serializable {
     implicit def toCategoryOps[F[_, _], A, B](target: F[A, B])(implicit tc: Category[F]): Ops[F, A, B] {
       type TypeClassType = Category[F]
     } = new Ops[F, A, B] {
@@ -168,7 +168,7 @@ object Profunctor {
    */
   @inline def apply[F[_, _]](implicit instance: Profunctor[F]): Profunctor[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Profunctor[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -177,7 +177,7 @@ object Profunctor {
     @inline final def rmap[C](f: B => C): F[A, C] = typeClassInstance.rmap[A, B, C](self)(f)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
-  trait ToProfunctorOps {
+  trait ToProfunctorOps extends Serializable {
     implicit def toProfunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Profunctor[F]): Ops[F, A, B] {
       type TypeClassType = Profunctor[F]
     } = new Ops[F, A, B] {

--- a/output/src/main/scala/fix/Invariant.scala
+++ b/output/src/main/scala/fix/Invariant.scala
@@ -37,14 +37,14 @@ object Invariant {
    */
   @inline def apply[F[_]](implicit instance: Invariant[F]): Invariant[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Invariant[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
     def imap[B](f: A => B)(g: B => A): F[B] = typeClassInstance.imap[A, B](self)(f)(g)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToInvariantOps {
+  trait ToInvariantOps extends Serializable {
     implicit def toInvariantOps[F[_], A](target: F[A])(implicit tc: Invariant[F]): Ops[F, A] {
       type TypeClassType = Invariant[F]
     } = new Ops[F, A] {
@@ -87,7 +87,7 @@ object InvariantSemigroupal {
    */
   @inline def apply[F[_]](implicit instance: InvariantSemigroupal[F]): InvariantSemigroupal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: InvariantSemigroupal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -96,7 +96,7 @@ object InvariantSemigroupal {
   trait AllOps[F[_], A] extends Ops[F, A] with Invariant.AllOps[F, A] {
     type TypeClassType <: InvariantSemigroupal[F]
   }
-  trait ToInvariantSemigroupalOps {
+  trait ToInvariantSemigroupalOps extends Serializable {
     implicit def toInvariantSemigroupalOps[F[_], A](target: F[A])(implicit tc: InvariantSemigroupal[F]): Ops[F, A] {
       type TypeClassType = InvariantSemigroupal[F]
     } = new Ops[F, A] {
@@ -137,13 +137,13 @@ object ContravariantSemigroupal {
    */
   @inline def apply[F[_]](implicit instance: ContravariantSemigroupal[F]): ContravariantSemigroupal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ContravariantSemigroupal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToContravariantSemigroupalOps {
+  trait ToContravariantSemigroupalOps extends Serializable {
     implicit def toContravariantSemigroupalOps[F[_], A](target: F[A])(implicit tc: ContravariantSemigroupal[F]): Ops[F, A] {
       type TypeClassType = ContravariantSemigroupal[F]
     } = new Ops[F, A] {

--- a/output/src/main/scala/fix/One.scala
+++ b/output/src/main/scala/fix/One.scala
@@ -24,14 +24,14 @@ object One {
    */
   @inline def apply[A](implicit instance: One[A]): One[A] = instance
 
-  trait Ops[A] {
+  trait Ops[A] extends Serializable {
     type TypeClassType <: One[A]
     def self: A
     val typeClassInstance: TypeClassType
     def isOne(implicit ev: Eq[A]): Boolean = typeClassInstance.isOne(self)(ev)
   }
   trait AllOps[A] extends Ops[A]
-  trait ToOneOps {
+  trait ToOneOps extends Serializable {
     implicit def toOneOps[A](target: A)(implicit tc: One[A]): Ops[A] {
       type TypeClassType = One[A]
     } = new Ops[A] {

--- a/rules/src/main/scala/org/typelevel/simulacrum/fix/TypeClassSupport.scala
+++ b/rules/src/main/scala/org/typelevel/simulacrum/fix/TypeClassSupport.scala
@@ -248,13 +248,13 @@ class TypeClassSupport extends SyntacticRule("TypeClassSupport") {
         |   */
         |  @inline def apply[$TypeParamDecl](implicit instance: $InstanceType): $InstanceType = instance
         |
-        |  trait Ops[$TypeParamsDecl] {
+        |  trait Ops[$TypeParamsDecl] extends Serializable {
         |    type TypeClassType <: $InstanceType
         |    def self: $ValueType
         |    val typeClassInstance: TypeClassType$Methods
         |  }
         |  trait AllOps[$TypeParamsDecl] extends Ops[$TypeParamsArgs]$AllOpsParents$AllOpsBody
-        |  trait To${Name}Ops {
+        |  trait To${Name}Ops extends Serializable {
         |    implicit def to${Name}Ops[$TypeParamsDecl](target: $ValueType)(implicit tc: $InstanceType): Ops[$TypeParamsArgs] {
         |      type TypeClassType = $InstanceType
         |    } = new Ops[$TypeParamsArgs] {


### PR DESCRIPTION
The `Ops` traits generated by Simulacrum have never been marked `Serializable`, which can [cause problems on Spark](https://github.com/typelevel/cats/pull/3439). We could make this an option but right now that seems like unnecessary complexity.

The important part here is adding `Serializable` to the `Ops` traits. I've also done the `ToXOps` ones for consistency, but I'm [hoping we can deprecate them soon anyway](https://github.com/typelevel/cats/issues/3330).