### PR TITLE
Support configurable deprecation for ops objects

### DIFF
--- a/input/src/main/scala/fix/Alternative.scala
+++ b/input/src/main/scala/fix/Alternative.scala
@@ -1,5 +1,9 @@
 /*
 rule = TypeClassSupport
+TypeClassSupport.opsObjectDeprecation = {
+  message = "Use cats.syntax object imports"
+  since = "2.2.0"
+}
  */
 package cats
 

--- a/output/src/main/scala/fix/Alternative.scala
+++ b/output/src/main/scala/fix/Alternative.scala
@@ -54,7 +54,6 @@ object Alternative extends AlternativeFunctions {
     def unite[G[_], B](implicit ev$1: A <:< G[B], FM: Monad[F], G: Bifoldable[G]): F[B] = typeClassInstance.unite[G, B](self.asInstanceOf[F[G[B]]])(FM, G)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  @deprecated("Use cats.syntax object imports", "2.2.0")
   trait ToAlternativeOps extends Serializable {
     implicit def toAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): Ops[F, A] {
       type TypeClassType = Alternative[F]

--- a/output/src/main/scala/fix/Alternative.scala
+++ b/output/src/main/scala/fix/Alternative.scala
@@ -54,6 +54,7 @@ object Alternative extends AlternativeFunctions {
     def unite[G[_], B](implicit ev$1: A <:< G[B], FM: Monad[F], G: Bifoldable[G]): F[B] = typeClassInstance.unite[G, B](self.asInstanceOf[F[G[B]]])(FM, G)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
+  @deprecated("Use cats.syntax object imports", "2.2.0")
   trait ToAlternativeOps extends Serializable {
     implicit def toAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): Ops[F, A] {
       type TypeClassType = Alternative[F]
@@ -63,7 +64,9 @@ object Alternative extends AlternativeFunctions {
       val typeClassInstance: TypeClassType = tc
     }
   }
+  @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToAlternativeOps
+  @deprecated("Use cats.syntax object imports", "2.2.0")
   object ops {
     implicit def toAllAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): AllOps[F, A] {
       type TypeClassType = Alternative[F]

--- a/rules/src/main/scala/org/typelevel/simulacrum/fix/TypeClassSupport.scala
+++ b/rules/src/main/scala/org/typelevel/simulacrum/fix/TypeClassSupport.scala
@@ -279,7 +279,7 @@ class TypeClassSupport(config: TypeClassSupportConfig) extends SyntacticRule("Ty
         |    val typeClassInstance: TypeClassType$Methods
         |  }
         |  trait AllOps[$TypeParamsDecl] extends Ops[$TypeParamsArgs]$AllOpsParents$AllOpsBody
-        |  ${deprecation}trait To${Name}Ops extends Serializable {
+        |  trait To${Name}Ops extends Serializable {
         |    implicit def to${Name}Ops[$TypeParamsDecl](target: $ValueType)(implicit tc: $InstanceType): Ops[$TypeParamsArgs] {
         |      type TypeClassType = $InstanceType
         |    } = new Ops[$TypeParamsArgs] {


### PR DESCRIPTION
Addresses [this issue](https://github.com/typelevel/cats/issues/3330). The default behavior is the same as in 0.2.0 (no deprecations).